### PR TITLE
Add case value (x86_64) to Settings.platform. Without it, project will n...

### DIFF
--- a/code/project/Settings.scala
+++ b/code/project/Settings.scala
@@ -152,7 +152,7 @@ object Helpers {
     val osArch =
       osArchProp match {
       case "i386" | "i486" | "i586" | "i686" => "x86"
-      case "amd64" | "x86-64" | "x64"        => "x86_64"
+      case "amd64" | "x86-64" | "x64" | "x86_64" => "x86_64"
     }
 
     osName + "-" + osArch


### PR DESCRIPTION
Add case value (x86_64) to Settings.platform. Without it, project will not compile on MacOS.